### PR TITLE
Support multi-item full_report results add PKD tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 .pycache
 run_tests
 .venv
+.idea/

--- a/litex/regon/__init__.py
+++ b/litex/regon/__init__.py
@@ -343,13 +343,19 @@ class REGONAPI(object):
             0,
             '//bir:DanePobierzPelnyRaportResult/text()'
         )
-        
+
         if mesg:
             result = objectify.fromstring(
                 mesg[0]
             )
-            result = result[0].dane
-            
+            dane_elements = result.findall('.//dane')
+
+            if len(dane_elements) > 1:
+                result = dane_elements
+            elif dane_elements:
+                result = dane_elements[0]
+            else:
+                self.raise_detailed_error()
         else:
             self.raise_detailed_error()
 

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,15 @@
+# REGON API credentials
+LR_USER_KEY=
+LR_SERVICE_URL=
+
+# Test data for sole proprietorship (SP)
+LR_TEST_NIP_SP=
+LR_TEST_REGON_SP=
+LR_TEST_NAME_SP=
+LR_TEST_PKD_SP=
+
+# Test data for company (CP)
+LR_TEST_NIP_CP=
+LR_TEST_REGON_CP=
+LR_TEST_NAME_CP=
+LR_TEST_PKD_CP=


### PR DESCRIPTION
The `full_report(regon, report_name)` method now correctly handles reports returning multiple `<dane>` elements (like PKD reports).  
Previously, only the first element was returned — now it returns:
- a **list** when multiple `<dane>` elements exist  
- a **single object** when only one is found (backward compatible)

Added tests for both sole proprietorship (`BIR11OsFizycznaPkd`) and corporation (`BIR11OsPrawnaPkd`) PKD reports to validate main PKD detection and structure.  
Also added `.env` handling and updated `.gitignore`.

### Changes
- `litex/regon/__init__.py`: extend `full_report` logic  
- `tests/test_regon_api.py`: new PKD tests  
- `.env` + `.gitignore`: local config support